### PR TITLE
Fix Chrome Dev/Beta package names

### DIFF
--- a/000gappsintegrator
+++ b/000gappsintegrator
@@ -19,7 +19,7 @@ gtmp=/data/local/tmp/gapp;
 sdkver=`getprop ro.build.version.sdk`;
 
 # find new unintegrated Google Apps APKs in /data
-for i in $(ls /data/app/ | grep -E 'com.android|com.google.android'); do
+for i in $(ls /data/app/ | grep -E 'com.android|com.google.android|com.chrome'); do
 
   # find equivalent /system APK name and only process if it exists
   xml=/data/system/packages.xml;


### PR DESCRIPTION
Chrome Dev and Beta start with `com.chrome` for some reason so that has to be added to the match list.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/osm0sis/gappsintegrator/1)

<!-- Reviewable:end -->
